### PR TITLE
Vault 7916 user group support

### DIFF
--- a/bootstrap/terraform/elasticache.tf
+++ b/bootstrap/terraform/elasticache.tf
@@ -7,19 +7,38 @@ provider "aws" {
   // region = ""
 }
 
+resource "random_password" "vault_plugin_elasticache_test" {
+  length = 16
+}
+
 resource "aws_elasticache_replication_group" "vault_plugin_elasticache_test" {
   replication_group_id       = "vault-plugin-elasticache-test"
   description                = "vault elasticache plugin generated test cluster"
-  engine                     = "redis"
+  engine                     = "REDIS"
   engine_version             = "6.2"
   node_type                  = "cache.t4g.micro"
   num_cache_clusters         = 1
   parameter_group_name       = "default.redis6.x"
   transit_encryption_enabled = true
+  user_group_ids             = [aws_elasticache_user_group.vault_plugin_elasticache_test.id]
 
   tags = {
     "description" : "vault elasticache plugin generated test cluster"
   }
+}
+
+resource "aws_elasticache_user_group" "vault_plugin_elasticache_test" {
+  engine        = "REDIS"
+  user_group_id = "vault-test-user-group"
+  user_ids      = ["default", aws_elasticache_user.vault_plugin_elasticache_test.user_id]
+}
+
+resource "aws_elasticache_user" "vault_plugin_elasticache_test" {
+  user_id       = "vault-test"
+  user_name     = "vault-test"
+  access_string = "on ~* +@all"
+  engine        = "REDIS"
+  passwords     = [random_password.vault_plugin_elasticache_test.result]
 }
 
 resource "aws_iam_user" "vault_plugin_elasticache_test" {
@@ -102,4 +121,9 @@ output "url" {
 data "aws_region" "current" {}
 output "region" {
   value = data.aws_region.current.name
+}
+
+// export TEST_ELASTICACHE_USER=${user}
+output "user" {
+  value = aws_elasticache_user.vault_plugin_elasticache_test.user_name
 }

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.17
 require (
 	github.com/aws/aws-sdk-go v1.44.81
 	github.com/hashicorp/go-hclog v1.2.2
+	github.com/hashicorp/go-secure-stdlib/awsutil v0.1.6
 	github.com/hashicorp/vault/sdk v0.5.3
 	github.com/mitchellh/mapstructure v1.5.0
 )
@@ -17,9 +18,10 @@ require (
 	github.com/golang/snappy v0.0.4 // indirect
 	github.com/google/go-cmp v0.5.7 // indirect
 	github.com/hashicorp/errwrap v1.1.0 // indirect
+	github.com/hashicorp/go-cleanhttp v0.5.2 // indirect
 	github.com/hashicorp/go-immutable-radix v1.3.1 // indirect
+	github.com/hashicorp/go-multierror v1.1.1 // indirect
 	github.com/hashicorp/go-plugin v1.4.3 // indirect
-	github.com/hashicorp/go-secure-stdlib/base62 v0.1.1 // indirect
 	github.com/hashicorp/go-secure-stdlib/mlock v0.1.1 // indirect
 	github.com/hashicorp/go-uuid v1.0.2 // indirect
 	github.com/hashicorp/go-version v1.2.0 // indirect
@@ -31,6 +33,7 @@ require (
 	github.com/mitchellh/go-testing-interface v1.0.0 // indirect
 	github.com/oklog/run v1.0.0 // indirect
 	github.com/pierrec/lz4 v2.5.2+incompatible // indirect
+	github.com/pkg/errors v0.9.1 // indirect
 	github.com/rogpeppe/go-internal v1.8.1 // indirect
 	golang.org/x/crypto v0.0.0-20210921155107-089bfa567519 // indirect
 	golang.org/x/net v0.0.0-20220127200216-cd36cc0744dd // indirect
@@ -39,4 +42,5 @@ require (
 	google.golang.org/genproto v0.0.0-20200526211855-cb27e3aa2013 // indirect
 	google.golang.org/grpc v1.41.0 // indirect
 	google.golang.org/protobuf v1.26.0 // indirect
+	gopkg.in/yaml.v2 v2.4.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -11,6 +11,7 @@ github.com/armon/go-metrics v0.3.9 h1:O2sNqxBdvq8Eq5xmzljcYzAORli6RWCvEym4cJf9m1
 github.com/armon/go-metrics v0.3.9/go.mod h1:4O98XIr/9W0sxpJ8UaYkvjk10Iff7SnFrb4QAOwNTFc=
 github.com/armon/go-radix v0.0.0-20180808171621-7fddfc383310/go.mod h1:ufUuZ+zHj4x4TnLV4JWEpy2hxWSpsRywHrMgIH9cCH8=
 github.com/armon/go-radix v1.0.0/go.mod h1:ufUuZ+zHj4x4TnLV4JWEpy2hxWSpsRywHrMgIH9cCH8=
+github.com/aws/aws-sdk-go v1.30.27/go.mod h1:5zCpMtNQVjRREroY7sYe8lOMRSxkhG6MZveU8YkpAk0=
 github.com/aws/aws-sdk-go v1.44.81 h1:C8oBZ+a+ka0qk3Q24MohQIFq0tkbO8IAu5tfpAMKVWE=
 github.com/aws/aws-sdk-go v1.44.81/go.mod h1:y4AeaBuwd2Lk+GepC1E9v0qOiTws0MIWAX4oIKwKHZo=
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24TaqPxmxbtue+5NUziq4I4S80YR8gNf3Q=
@@ -51,6 +52,7 @@ github.com/go-kit/kit v0.9.0/go.mod h1:xBxKIO96dXMWWy0MnWVtmwkA9/13aqxPnvrjFYMA2
 github.com/go-ldap/ldap/v3 v3.1.10/go.mod h1:5Zun81jBTabRaI8lzN7E1JjyEl1g6zI6u9pd8luAK4Q=
 github.com/go-logfmt/logfmt v0.3.0/go.mod h1:Qt1PoO58o5twSAckw1HlFXLmHsOX5/0LbT9GBnD5lWE=
 github.com/go-logfmt/logfmt v0.4.0/go.mod h1:3RMwSq7FuexP4Kalkev3ejPJsZTpXXBr9+V4qmtdjCk=
+github.com/go-sql-driver/mysql v1.5.0/go.mod h1:DCzpHaOWr8IXmIStZouvnhqoel9Qv2LBy8hT2VhHyBg=
 github.com/go-stack/stack v1.8.0/go.mod h1:v0f6uXyyMGvRgIKkXu+yp6POWl0qKG85gN/melR3HDY=
 github.com/go-test/deep v1.0.2/go.mod h1:wGDj63lr65AM2AQyKZd/NYHGb0R+1RLqB8NKt3aSFNA=
 github.com/gogo/protobuf v1.1.1/go.mod h1:r8qH/GZQm5c6nD/R0oafs1akxWv10x8SbQlK7atdtwQ=
@@ -89,6 +91,8 @@ github.com/hashicorp/errwrap v1.0.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brv
 github.com/hashicorp/errwrap v1.1.0 h1:OxrOeh75EUXMY8TBjag2fzXGZ40LB6IKw45YeGUDY2I=
 github.com/hashicorp/errwrap v1.1.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=
 github.com/hashicorp/go-cleanhttp v0.5.0/go.mod h1:JpRdi6/HCYpAwUzNwuwqhbovhLtngrth3wmdIIUrZ80=
+github.com/hashicorp/go-cleanhttp v0.5.2 h1:035FKYIWjmULyFRBKPs8TBQoi0x6d9G4xc9neXJWAZQ=
+github.com/hashicorp/go-cleanhttp v0.5.2/go.mod h1:kO/YDlP8L1346E6Sodw+PrpBSV4/SoxCXGY6BqNFT48=
 github.com/hashicorp/go-hclog v0.14.1/go.mod h1:whpDNt7SSdeAju8AWKIWsul05p54N/39EeqMAyrmvFQ=
 github.com/hashicorp/go-hclog v0.16.2/go.mod h1:whpDNt7SSdeAju8AWKIWsul05p54N/39EeqMAyrmvFQ=
 github.com/hashicorp/go-hclog v1.2.2 h1:ihRI7YFwcZdiSD7SIenIhHfQH3OuDvWerAUBZbeQS3M=
@@ -98,11 +102,13 @@ github.com/hashicorp/go-immutable-radix v1.3.1 h1:DKHmCUm2hRBK510BaiZlwvpD40f8bJ
 github.com/hashicorp/go-immutable-radix v1.3.1/go.mod h1:0y9vanUI8NX6FsYoO3zeMjhV/C5i9g4Q3DwcSNZ4P60=
 github.com/hashicorp/go-kms-wrapping/entropy v0.1.0/go.mod h1:d1g9WGtAunDNpek8jUIEJnBlbgKS1N2Q61QkHiZyR1g=
 github.com/hashicorp/go-multierror v1.0.0/go.mod h1:dHtQlpGsu+cZNNAkkCN/P3hoUDHhCYQXV3UM06sGGrk=
+github.com/hashicorp/go-multierror v1.1.1 h1:H5DkEtf6CXdFp0N0Em5UCwQpXMWke8IA0+lD48awMYo=
 github.com/hashicorp/go-multierror v1.1.1/go.mod h1:iw975J/qwKPdAO1clOe2L8331t/9/fmwbPZ6JB6eMoM=
 github.com/hashicorp/go-plugin v1.4.3 h1:DXmvivbWD5qdiBts9TpBC7BYL1Aia5sxbRgQB+v6UZM=
 github.com/hashicorp/go-plugin v1.4.3/go.mod h1:5fGEH17QVwTTcR0zV7yhDPLLmFX9YSZ38b18Udy6vYQ=
 github.com/hashicorp/go-retryablehttp v0.5.3/go.mod h1:9B5zBasrRhHXnJnui7y6sL7es7NDiJgTc6Er0maI1Xs=
-github.com/hashicorp/go-secure-stdlib/base62 v0.1.1 h1:6KMBnfEv0/kLAz0O76sliN5mXbCDcLfs2kP7ssP7+DQ=
+github.com/hashicorp/go-secure-stdlib/awsutil v0.1.6 h1:W9WN8p6moV1fjKLkeqEgkAMu5rauy9QeYDAmIaPuuiA=
+github.com/hashicorp/go-secure-stdlib/awsutil v0.1.6/go.mod h1:MpCPSPGLDILGb4JMm94/mMi3YysIqsXzGCzkEZjcjXg=
 github.com/hashicorp/go-secure-stdlib/base62 v0.1.1/go.mod h1:EdWO6czbmthiwZ3/PUsDV+UD1D5IRU4ActiaWGwt0Yw=
 github.com/hashicorp/go-secure-stdlib/mlock v0.1.1 h1:cCRo8gK7oq6A2L6LICkUZ+/a5rLiRXFMf1Qd4xSwxTc=
 github.com/hashicorp/go-secure-stdlib/mlock v0.1.1/go.mod h1:zq93CJChV6L9QTfGKtfBxKqD7BqqXx5O04A/ns2p5+I=
@@ -129,6 +135,7 @@ github.com/hashicorp/yamux v0.0.0-20180604194846-3520598351bb/go.mod h1:+NfK9FKe
 github.com/jessevdk/go-flags v1.4.0/go.mod h1:4FA24M0QyGHXBuZZK/XkWh8h0e1EYbRYJSGM75WSRxI=
 github.com/jhump/protoreflect v1.6.0 h1:h5jfMVslIg6l29nsMs0D8Wj17RDVdNYti0vDN/PZZoE=
 github.com/jhump/protoreflect v1.6.0/go.mod h1:eaTn3RZAmMBcV0fifFvlm6VHNz3wSkYyXYWUh7ymB74=
+github.com/jmespath/go-jmespath v0.3.0/go.mod h1:9QtRXoHjLGCJ5IBSaohpXITPlowMeeYCZ7fLUTSywik=
 github.com/jmespath/go-jmespath v0.4.0 h1:BEgLn5cpjn8UN1mAw4NjwDrS35OdebyEtFe+9YPoQUg=
 github.com/jmespath/go-jmespath v0.4.0/go.mod h1:T8mJZnbsbmF+m6zOOFylbeCJqk5+pHWvzYPziyZiYoo=
 github.com/jmespath/go-jmespath/internal/testify v1.5.1 h1:shLQSRRSCCPj3f2gpwzGwWFoC7ycTf1rcQZHOlsJ6N8=
@@ -183,6 +190,7 @@ github.com/pierrec/lz4 v2.5.2+incompatible/go.mod h1:pdkljMzZIN41W+lC3N2tnIh5sFi
 github.com/pkg/diff v0.0.0-20210226163009-20ebb0f2a09e/go.mod h1:pJLUxLENpZxwdsKMEsNbx1VGcRFpLqf3715MtcvvzbA=
 github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
+github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
@@ -239,6 +247,7 @@ golang.org/x/net v0.0.0-20190213061140-3a22650c66bd/go.mod h1:mL1N/T3taQHkDXs73r
 golang.org/x/net v0.0.0-20190311183353-d8887717615a/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
 golang.org/x/net v0.0.0-20190404232315-eb5bcb51f2a3/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
 golang.org/x/net v0.0.0-20190613194153-d28f0bde5980/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
+golang.org/x/net v0.0.0-20200202094626-16171245cfb2/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20200822124328-c89045814202/go.mod h1:/O7V0waA8r7cgGh81Ro3o1hOxt32SMVPicZroKQ2sZA=
 golang.org/x/net v0.0.0-20210226172049-e18ecbb05110/go.mod h1:m0MpNAwzfU5UDzcl9v0D8zg8gWTRqZa9RBIspLL5mdg=
 golang.org/x/net v0.0.0-20220127200216-cd36cc0744dd h1:O7DYs+zxREGLKzKoMQrtrEacpb0ZVXA5rIwylE2Xchk=
@@ -263,6 +272,7 @@ golang.org/x/sys v0.0.0-20200116001909-b77594299b42/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20200122134326-e047566fdf82/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200223170610-d5e6a3e2c0ae/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200323222414-85ca7c5b95cd/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20200602225109-6fdc65e7d980/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20201119102817-f84b799fce68/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210615035016-665e8c7367d1/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20210630005230-0f9fa26af87c/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
@@ -324,8 +334,9 @@ gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.3/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.4/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.5/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
-gopkg.in/yaml.v2 v2.2.8 h1:obN1ZagJSUGI0Ek/LBmuj4SNLPfIny3KsKFopxRdj10=
 gopkg.in/yaml.v2 v2.2.8/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
+gopkg.in/yaml.v2 v2.4.0 h1:D8xgwECY7CYvx+Y2n4sBz93Jn9JRvxdiyyo8CTfuKaY=
+gopkg.in/yaml.v2 v2.4.0/go.mod h1:RDklbk79AGWmwhnvt/jBztapEOGDOx6ZbXqjP6csGnQ=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/redis_elasticache_client.go
+++ b/redis_elasticache_client.go
@@ -2,28 +2,16 @@ package rediselasticache
 
 import (
 	"context"
-	"encoding/json"
-	"errors"
 	"fmt"
-	"regexp"
-	"strings"
 	"time"
-	"unicode"
 
 	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/aws/awserr"
-	"github.com/aws/aws-sdk-go/aws/credentials"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/elasticache"
 	"github.com/hashicorp/go-hclog"
+	"github.com/hashicorp/go-secure-stdlib/awsutil"
 	"github.com/hashicorp/vault/sdk/database/dbplugin/v5"
-	"github.com/hashicorp/vault/sdk/database/helper/credsutil"
 	"github.com/mitchellh/mapstructure"
-)
-
-var (
-	nonAlphanumericHyphenRegex = regexp.MustCompile("[^a-zA-Z\\d-]+")
-	doubleHyphenRegex          = regexp.MustCompile("-{2,}")
 )
 
 // Verify interface is implemented
@@ -49,9 +37,19 @@ func (r *redisElastiCacheDB) Initialize(_ context.Context, req dbplugin.Initiali
 		return dbplugin.InitializeResponse{}, err
 	}
 
+	creds, err := awsutil.RetrieveCreds(r.config.Username, r.config.Password, "", r.logger)
+	if err != nil {
+		return dbplugin.InitializeResponse{}, fmt.Errorf("unable to rerieve AWS credentials from provider chain: %w", err)
+	}
+
+	region, err := awsutil.GetRegion(r.config.Region)
+	if err != nil {
+		return dbplugin.InitializeResponse{}, fmt.Errorf("unable to determine AWS region from config nor context: %w", err)
+	}
+
 	sess, err := session.NewSession(&aws.Config{
-		Region:      aws.String(r.config.Region),
-		Credentials: credentials.NewStaticCredentials(r.config.Username, r.config.Password, ""),
+		Region:      aws.String(region),
+		Credentials: creds,
 	})
 	if err != nil {
 		return dbplugin.InitializeResponse{}, fmt.Errorf("unable to initialize AWS session: %w", err)
@@ -80,264 +78,52 @@ func (r *redisElastiCacheDB) Close() error {
 	return nil
 }
 
-func (r *redisElastiCacheDB) NewUser(_ context.Context, req dbplugin.NewUserRequest) (dbplugin.NewUserResponse, error) {
-	r.logger.Debug("creating new AWS ElastiCache Redis user", "role", req.UsernameConfig.RoleName)
+func (r *redisElastiCacheDB) NewUser(_ context.Context, _ dbplugin.NewUserRequest) (dbplugin.NewUserResponse, error) {
+	return dbplugin.NewUserResponse{}, fmt.Errorf("user creation not supported")
+}
 
-	// Format: v_{displayName}_{roleName}_{ID[20]}_{epoch[11]}
-	// Length limits set so unique identifiers are not truncated
-	username, err := credsutil.GenerateUsername(
-		credsutil.DisplayName(req.UsernameConfig.DisplayName, 5),
-		credsutil.RoleName(req.UsernameConfig.RoleName, 39),
-		credsutil.MaxLength(80),
-	)
-	if err != nil {
-		return dbplugin.NewUserResponse{}, fmt.Errorf("unable to generate username: %w", err)
-	}
-
-	accessString, err := parseCreationCommands(req.Statements.Commands)
-	if err != nil {
-		return dbplugin.NewUserResponse{}, fmt.Errorf("unable to parse access string: %w", err)
-	}
-
-	userId := normaliseId(username)
-
-	output, err := r.client.CreateUser(&elasticache.CreateUserInput{
-		AccessString:       aws.String(accessString),
-		Engine:             aws.String("Redis"),
-		NoPasswordRequired: aws.Bool(false),
-		Passwords:          []*string{&req.Password},
-		Tags:               []*elasticache.Tag{},
-		UserId:             aws.String(userId),
-		UserName:           aws.String(username),
-	})
-	if err != nil {
-		return dbplugin.NewUserResponse{}, fmt.Errorf("unable to create new user: %w", err)
-	}
-	r.waitForUserActiveState(userId)
-
-	if err = r.associateUserWithReplicationGroup(userId); err != nil {
-		r.logger.Debug("encountered error while associating newly created user, attempting to clean up", "user id", userId)
-		_, _ = r.DeleteUser(nil, dbplugin.DeleteUserRequest{
-			Username: userId,
-		})
-		return dbplugin.NewUserResponse{}, fmt.Errorf("unable to configure newly created user %s: %w", userId, err)
-	}
-
-	return dbplugin.NewUserResponse{Username: *output.UserName}, nil
+func (r *redisElastiCacheDB) DeleteUser(_ context.Context, _ dbplugin.DeleteUserRequest) (dbplugin.DeleteUserResponse, error) {
+	return dbplugin.DeleteUserResponse{}, fmt.Errorf("user deletion not supported")
 }
 
 func (r *redisElastiCacheDB) UpdateUser(_ context.Context, req dbplugin.UpdateUserRequest) (dbplugin.UpdateUserResponse, error) {
 	r.logger.Debug("updating AWS ElastiCache Redis user", "username", req.Username)
 
-	userId := normaliseId(req.Username)
-
-	if r.waitForUserActiveState(userId) {
-		_, err := r.client.ModifyUser(&elasticache.ModifyUserInput{
-			UserId:    &userId,
-			Passwords: []*string{&req.Password.NewPassword},
-		})
-		if err != nil {
-			return dbplugin.UpdateUserResponse{}, fmt.Errorf("unable to update user %s: %w", userId, err)
-		}
-
-		return dbplugin.UpdateUserResponse{}, nil
-	} else {
-		return dbplugin.UpdateUserResponse{}, fmt.Errorf("unable to update user %s, user never turned active", userId)
-	}
-}
-
-func (r *redisElastiCacheDB) DeleteUser(_ context.Context, req dbplugin.DeleteUserRequest) (dbplugin.DeleteUserResponse, error) {
-	r.logger.Debug("deleting AWS ElastiCache Redis user", "username", req.Username)
-
-	userId := normaliseId(req.Username)
-
-	out, err := r.client.DescribeUsers(&elasticache.DescribeUsersInput{UserId: aws.String(userId)})
-	if (err != nil && err.(awserr.Error).Code() == "UserNotFound") || (out != nil && len(out.Users) == 1 && *out.Users[0].Status == "deleting") {
-		r.logger.Debug("user does not exist or is being deleted, considering deletion successful", "user id", userId)
-		return dbplugin.DeleteUserResponse{}, nil
-	}
-
-	if r.waitForUserActiveState(userId) {
-		_, err = r.client.DeleteUser(&elasticache.DeleteUserInput{
-			UserId: &userId,
-		})
-	} else {
-		err = fmt.Errorf("unable to delete user %s, user never turned active", userId)
-	}
-
-	return dbplugin.DeleteUserResponse{}, err
-}
-
-// If replication group already has an associated user group, we use it
-// If not and a default user group already exists, we associate it
-// If not and a default group does not exist, we create and associate it
-func (r *redisElastiCacheDB) associateUserWithReplicationGroup(userId string) error {
-	replicationGroupId := r.extractReplicationGroupId()
-	userGroupId, err := r.extractUserGroupId(replicationGroupId)
+	out, err := r.client.DescribeUsers(&elasticache.DescribeUsersInput{
+		UserId: aws.String(req.Username),
+	})
 	if err != nil {
-		return fmt.Errorf("unable to determine if replication group %s already has an associated user group", replicationGroupId)
+		return dbplugin.UpdateUserResponse{}, fmt.Errorf("unable to get user %s: %w", req.Username, err)
+	}
+	if len(out.Users) == 1 && *out.Users[0].Status != "active" {
+		return dbplugin.UpdateUserResponse{}, fmt.Errorf("user %s cannot be updated because it is not in the 'active' state", req.Username)
 	}
 
-	if userGroupId != "" {
-		if r.waitForGroupActiveState(userGroupId) {
-			_, err = r.client.ModifyUserGroup(&elasticache.ModifyUserGroupInput{
-				UserGroupId:  aws.String(userGroupId),
-				UserIdsToAdd: []*string{aws.String(userId)},
-			})
-		} else {
-			err = fmt.Errorf("unable to update user group %s, user group never turned active", replicationGroupId)
-		}
-	} else {
-		r.logger.Debug("configuring user group for replication group", "replication group id", replicationGroupId)
-
-		_, err = r.client.DescribeUserGroups(&elasticache.DescribeUserGroupsInput{
-			UserGroupId: aws.String(replicationGroupId),
-		})
-		if err != nil && err.(awserr.Error).Code() == "UserGroupNotFound" {
-			_, err = r.client.CreateUserGroup(&elasticache.CreateUserGroupInput{
-				Engine:      aws.String("Redis"),
-				Tags:        []*elasticache.Tag{},
-				UserGroupId: aws.String(replicationGroupId),
-				UserIds: []*string{
-					aws.String("default"), // User groups must contain a user with the username default
-					aws.String(userId),
-				},
-			})
-		}
-
-		if r.waitForGroupActiveState(replicationGroupId) {
-			_, err = r.client.ModifyReplicationGroup(&elasticache.ModifyReplicationGroupInput{
-				ReplicationGroupId: aws.String(replicationGroupId),
-				UserGroupIdsToAdd:  []*string{aws.String(replicationGroupId)},
-			})
-		} else {
-			err = fmt.Errorf("unable to update replication group %s, newly created user group never turned active", replicationGroupId)
-		}
-	}
-
-	return err
-}
-
-// Replication groups can have none or up to 1 associated user group at any given time
-func (r *redisElastiCacheDB) extractUserGroupId(replicationGroupId string) (string, error) {
-	out, err := r.client.DescribeReplicationGroups(&elasticache.DescribeReplicationGroupsInput{
-		ReplicationGroupId: aws.String(replicationGroupId),
+	_, err = r.client.ModifyUser(&elasticache.ModifyUserInput{
+		UserId:    &req.Username,
+		Passwords: []*string{&req.Password.NewPassword},
 	})
-
-	userGroupId := ""
-	if err == nil && len(out.ReplicationGroups) == 1 && len(out.ReplicationGroups[0].UserGroupIds) == 1 {
-		userGroupId = *out.ReplicationGroups[0].UserGroupIds[0]
+	if err != nil {
+		return dbplugin.UpdateUserResponse{}, fmt.Errorf("unable to update user %s: %w", req.Username, err)
 	}
 
-	return userGroupId, err
-}
-
-// Elasticache URLs are always in the form of prefix.cluster-id.dns-suffix:port and cluster ids nor prefix cannot contain "." characters
-func (r *redisElastiCacheDB) extractReplicationGroupId() string {
-	_, after, found := strings.Cut(r.config.Url, ".")
-	if found {
-		before, _, found := strings.Cut(after, ".")
-		if found {
-			return normaliseId(before)
-		}
-	}
-
-	return ""
-}
-
-func (r *redisElastiCacheDB) waitForGroupActiveState(userGroupId string) bool {
-	return retry(userGroupId, func(s string) (bool, error) {
-		out, err := r.client.DescribeUserGroups(&elasticache.DescribeUserGroupsInput{
-			UserGroupId: aws.String(userGroupId),
-		})
-
-		if err != nil {
-			return false, err
-		} else {
-			return len(out.UserGroups) == 1 && *out.UserGroups[0].Status == "active", nil
-		}
-	})
+	return dbplugin.UpdateUserResponse{}, nil
 }
 
 func (r *redisElastiCacheDB) waitForUserActiveState(userId string) bool {
-	return retry(userId, func(s string) (bool, error) {
-		out, err := r.client.DescribeUsers(&elasticache.DescribeUsersInput{
+	isActive := false
+
+	for i := 0; i <= 50; i++ {
+		user, err := r.client.DescribeUsers(&elasticache.DescribeUsersInput{
 			UserId: aws.String(userId),
 		})
-
-		if err != nil {
-			return false, err
-		} else {
-			return len(out.Users) == 1 && *out.Users[0].Status == "active", nil
-		}
-	})
-}
-
-func retry(s string, f func(string) (bool, error)) bool {
-	for i := 0; i < 50; i++ {
-		ok, err := f(s)
-		if err != nil {
-			return false
-		} else if ok {
-			return true
+		if err != nil && len(user.Users) == 1 && *user.Users[0].Status == "active" {
+			isActive = true
+			break
 		} else {
 			time.Sleep(3 * time.Second)
 		}
 	}
 
-	return false
-}
-
-func parseCreationCommands(commands []string) (string, error) {
-	if len(commands) == 0 {
-		return "on ~* +@read", nil
-	}
-
-	accessString := ""
-	for _, command := range commands {
-		var rules []string
-		err := json.Unmarshal([]byte(command), &rules)
-		if err != nil {
-			return "", err
-		}
-
-		if len(rules) > 0 {
-			accessString += strings.Join(rules, " ")
-			accessString += " "
-		}
-	}
-
-	if strings.HasPrefix(accessString, "off ") || strings.Contains(accessString, " off ") || strings.HasSuffix(accessString, " off") {
-		return "", errors.New("creation of disabled or 'off' users is forbidden")
-	}
-
-	if !(strings.HasPrefix(accessString, "on ") || strings.Contains(accessString, " on ") || strings.HasSuffix(accessString, " on")) {
-		accessString = "on " + accessString
-	}
-
-	accessString = strings.TrimSpace(accessString)
-
-	return accessString, nil
-}
-
-// All Elasticache IDs can have up to 40 characters, and must begin with a letter.
-// It should not end with a hyphen or contain two consecutive hyphens.
-// Valid characters: A-Z, a-z, 0-9, and -(hyphen).
-func normaliseId(raw string) string {
-	normalized := nonAlphanumericHyphenRegex.ReplaceAllString(raw, "")
-	normalized = doubleHyphenRegex.ReplaceAllString(normalized, "")
-
-	if len(normalized) > 40 {
-		normalized = normalized[len(normalized)-40:]
-	}
-
-	if unicode.IsNumber(rune(normalized[0])) {
-		normalized = string(rune('A'-17+normalized[0])) + normalized[1:]
-	}
-
-	if strings.HasSuffix(normalized, "-") {
-		normalized = normalized[:len(normalized)-1] + "x"
-	}
-
-	return normalized
+	return isActive
 }

--- a/redis_elasticache_client_test.go
+++ b/redis_elasticache_client_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"os"
 	"reflect"
-	"strings"
 	"testing"
 
 	"github.com/aws/aws-sdk-go/service/elasticache"
@@ -31,17 +30,18 @@ type testCases []struct {
 	wantErr bool
 }
 
-func skipIfEnvIsUnset(t *testing.T, config config) {
-	if config.Username == "" || config.Password == "" || config.Url == "" || config.Region == "" {
+func skipIfEnvIsUnset(t *testing.T, config config, username string) {
+	if config.Username == "" || config.Password == "" || config.Url == "" || config.Region == "" || username == "" {
 		t.Skip("Skipping acceptance tests because required environment variables are not configured")
 	}
 }
 
-func setUpEnvironment() (fields, map[string]interface{}, redisElastiCacheDB) {
+func setUpEnvironment() (fields, map[string]interface{}, redisElastiCacheDB, string) {
 	username := os.Getenv("TEST_ELASTICACHE_USERNAME")
 	password := os.Getenv("TEST_ELASTICACHE_PASSWORD")
 	url := os.Getenv("TEST_ELASTICACHE_URL")
 	region := os.Getenv("TEST_ELASTICACHE_REGION")
+	user := os.Getenv("TEST_ELASTICACHE_USER")
 
 	f := fields{
 		logger: hclog.New(&hclog.LoggerOptions{
@@ -71,7 +71,7 @@ func setUpEnvironment() (fields, map[string]interface{}, redisElastiCacheDB) {
 		client: f.client,
 	}
 
-	return f, c, r
+	return f, c, r, user
 }
 
 func setUpClient(t *testing.T, r *redisElastiCacheDB, config map[string]interface{}) {
@@ -84,37 +84,9 @@ func setUpClient(t *testing.T, r *redisElastiCacheDB, config map[string]interfac
 	}
 }
 
-func setUpTestUser(t *testing.T, r *redisElastiCacheDB) string {
-	user, err := r.NewUser(nil, dbplugin.NewUserRequest{
-		UsernameConfig: dbplugin.UsernameMetadata{
-			DisplayName: "display",
-			RoleName:    "role",
-		},
-		Statements: dbplugin.Statements{
-			Commands: []string{"[\"~test*\",\"-@all\",\"+@read\"]"},
-		},
-		Password: "abcdefghijklmnopqrstuvwxyz",
-	})
-	if err != nil {
-		t.Errorf("unable to provision test user for test cases: %v", err)
-	}
-
-	return user.Username
-}
-
-func teardownTestUser(r redisElastiCacheDB, username string) {
-	if username == "" {
-		return
-	}
-
-	_, _ = r.DeleteUser(nil, dbplugin.DeleteUserRequest{
-		Username: username,
-	})
-}
-
 func Test_redisElastiCacheDB_Initialize(t *testing.T) {
-	f, c, r := setUpEnvironment()
-	skipIfEnvIsUnset(t, f.config)
+	f, c, r, u := setUpEnvironment()
+	skipIfEnvIsUnset(t, f.config, u)
 
 	tests := testCases{
 		{
@@ -163,117 +135,11 @@ func Test_redisElastiCacheDB_Initialize(t *testing.T) {
 	}
 }
 
-func Test_redisElastiCacheDB_NewUser(t *testing.T) {
-	f, c, r := setUpEnvironment()
-
-	skipIfEnvIsUnset(t, f.config)
-
-	setUpClient(t, &r, c)
-
-	tests := testCases{
-		{
-			name:   "create new valid user succeeds",
-			fields: f,
-			args: args{
-				ctx: context.Background(),
-				req: dbplugin.NewUserRequest{
-					UsernameConfig: dbplugin.UsernameMetadata{
-						DisplayName: "display",
-						RoleName:    "role",
-					},
-					Statements: dbplugin.Statements{
-						Commands: []string{"[\"~test*\",\"-@all\",\"+@read\"]"},
-					},
-					Password: "abcdefghijklmnopqrstuvwxyz",
-				},
-			},
-			want: dbplugin.NewUserResponse{
-				Username: "v_displ_role_",
-			},
-		},
-		{
-			name:   "create user truncates username",
-			fields: f,
-			args: args{
-				ctx: context.Background(),
-				req: dbplugin.NewUserRequest{
-					UsernameConfig: dbplugin.UsernameMetadata{
-						DisplayName: "iAmSupeExtremelyLongThisWillHaveToBeTruncated",
-						RoleName:    "iAmEvenLongerTheApiWillDefinitelyRejectUsIfWeArePassedAsIsWithoutAnyModifications",
-					},
-					Statements: dbplugin.Statements{
-						Commands: []string{"[\"~test*\",\"-@all\",\"+@read\"]"},
-					},
-					Password: "abcdefghijklmnopqrstuvwxyz",
-				},
-			},
-			want: dbplugin.NewUserResponse{
-				Username: "v_iAmSu_iAmEvenLongerTheApiWillDefinitelyRejec",
-			},
-		},
-		{
-			name:   "create user with invalid password fails",
-			fields: f,
-			args: args{
-				ctx: context.Background(),
-				req: dbplugin.NewUserRequest{
-					UsernameConfig: dbplugin.UsernameMetadata{
-						DisplayName: "display",
-						RoleName:    "role",
-					},
-					Statements: dbplugin.Statements{
-						Commands: []string{"[\"~test*\",\"-@all\",\"+@read\"]"},
-					},
-					Password: "too short",
-				},
-			},
-			want:    dbplugin.NewUserResponse{},
-			wantErr: true,
-		},
-		{
-			name:   "create user with invalid statements fails",
-			fields: f,
-			args: args{
-				ctx: context.Background(),
-				req: dbplugin.NewUserRequest{
-					UsernameConfig: dbplugin.UsernameMetadata{
-						DisplayName: "display",
-						RoleName:    "role",
-					},
-					Statements: dbplugin.Statements{
-						Commands: []string{"+@invalid"},
-					},
-					Password: "abcdefghijklmnopqrstuvwxyz",
-				},
-			},
-			want:    dbplugin.NewUserResponse{},
-			wantErr: true,
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			got, err := r.NewUser(tt.args.ctx, tt.args.req.(dbplugin.NewUserRequest))
-			if (err != nil) != tt.wantErr {
-				t.Errorf("NewUser() error = %v, wantErr %v", err, tt.wantErr)
-				return
-			}
-			if !strings.HasPrefix(got.Username, tt.want.(dbplugin.NewUserResponse).Username) {
-				t.Errorf("NewUser() got = %v, want %v", got, tt.want)
-			}
-
-			teardownTestUser(r, got.Username)
-		})
-	}
-}
-
 func Test_redisElastiCacheDB_UpdateUser(t *testing.T) {
-	f, c, r := setUpEnvironment()
+	f, c, r, u := setUpEnvironment()
 
-	skipIfEnvIsUnset(t, f.config)
-
+	skipIfEnvIsUnset(t, f.config, u)
 	setUpClient(t, &r, c)
-	username := setUpTestUser(t, &r)
-	defer teardownTestUser(r, username)
 
 	tests := testCases{
 		{
@@ -282,7 +148,7 @@ func Test_redisElastiCacheDB_UpdateUser(t *testing.T) {
 			args: args{
 				ctx: context.Background(),
 				req: dbplugin.UpdateUserRequest{
-					Username:       username,
+					Username:       u,
 					CredentialType: 0,
 					Password: &dbplugin.ChangePassword{
 						NewPassword: "abcdefghijklmnopqrstuvwxyz1",
@@ -313,7 +179,7 @@ func Test_redisElastiCacheDB_UpdateUser(t *testing.T) {
 			args: args{
 				ctx: context.Background(),
 				req: dbplugin.UpdateUserRequest{
-					Username:       username,
+					Username:       u,
 					CredentialType: 0,
 					Password: &dbplugin.ChangePassword{
 						NewPassword: "too short",
@@ -333,175 +199,6 @@ func Test_redisElastiCacheDB_UpdateUser(t *testing.T) {
 			}
 			if !reflect.DeepEqual(got, tt.want) {
 				t.Errorf("UpdateUser() got = %v, want %v", got, tt.want)
-			}
-		})
-	}
-}
-
-func Test_redisElastiCacheDB_DeleteUser(t *testing.T) {
-	f, c, r := setUpEnvironment()
-
-	skipIfEnvIsUnset(t, f.config)
-
-	setUpClient(t, &r, c)
-	username := setUpTestUser(t, &r)
-
-	tests := testCases{
-		{
-			name:   "delete existing user succeeds",
-			fields: f,
-			args: args{
-				ctx: context.Background(),
-				req: dbplugin.DeleteUserRequest{
-					Username: username,
-				},
-			},
-			want:    dbplugin.DeleteUserResponse{},
-			wantErr: false,
-		},
-		{
-			name:   "delete non-existing user is lenient",
-			fields: f,
-			args: args{
-				ctx: context.Background(),
-				req: dbplugin.DeleteUserRequest{
-					Username: "I do not exist",
-				},
-			},
-			want: dbplugin.DeleteUserResponse{},
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			got, err := r.DeleteUser(tt.args.ctx, tt.args.req.(dbplugin.DeleteUserRequest))
-			if (err != nil) != tt.wantErr {
-				t.Errorf("DeleteUser() error = %v, wantErr %v", err, tt.wantErr)
-				return
-			}
-			if !reflect.DeepEqual(got, tt.want) {
-				t.Errorf("DeleteUser() got = %v, want %v", got, tt.want)
-			}
-		})
-	}
-}
-
-func Test_parseCreationCommands(t *testing.T) {
-	type testCases []struct {
-		name     string
-		commands []string
-		want     string
-		wantErr  bool
-	}
-
-	tests := testCases{
-		{
-			name:     "empty command returns read-only user",
-			commands: []string{},
-			want:     "on ~* +@read",
-		},
-		{
-			name:     "single command with multiple rules parses correctly",
-			commands: []string{"[\"~test*\",\"-@all\",\"+@read\"]"},
-			want:     "on ~test* -@all +@read",
-		},
-		{
-			name:     "multiple commands with multiple rules parses correctly",
-			commands: []string{"[\"~test*\"]", "[\"-@all\", \"+@read\"]"},
-			want:     "on ~test* -@all +@read",
-		},
-		{
-			name:     "empty commands are tolerated",
-			commands: []string{"[\"~test*\"]", "[]", "[\"-@all\", \"+@read\"]"},
-			want:     "on ~test* -@all +@read",
-		},
-		{
-			name:     "'on' is added if missing for convenience",
-			commands: []string{"[\"~test*\"]"},
-			want:     "on ~test*",
-		},
-		{
-			name:     "'on' is ignored if passed at the beginning",
-			commands: []string{"[\"on\", \"~test*\"]"},
-			want:     "on ~test*",
-		},
-		{
-			name:     "'on' is ignored if passed explicitly within the rules",
-			commands: []string{"[\"~test*\", \"on\"]", "[\"+@read\"]"},
-			want:     "~test* on +@read",
-		},
-		{
-			name:     "'on' is ignored if passed explicitly at the end",
-			commands: []string{"[\"~test*\", \"on\"]"},
-			want:     "~test* on",
-		},
-		{
-			name:     "parsing invalid command format fails",
-			commands: []string{"{\"command:\", \"on ~* +@read\"}"},
-			want:     "",
-			wantErr:  true,
-		},
-		{
-			name:     "creation of disabled users is forbidden",
-			commands: []string{"[\"~test*\", \"off\"]", "[\"+@read\"]"},
-			want:     "",
-			wantErr:  true,
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			got, err := parseCreationCommands(tt.commands)
-			if (err != nil) != tt.wantErr {
-				t.Errorf("parseCreationCommands() error = %v, wantErr %v", err, tt.wantErr)
-				return
-			}
-			if got != tt.want {
-				t.Errorf("parseCreationCommands() got = %v, want %v", got, tt.want)
-			}
-		})
-	}
-}
-
-func Test_normaliseId(t *testing.T) {
-	type args struct {
-		username string
-	}
-
-	tests := []struct {
-		name string
-		args args
-		want string
-	}{
-		{
-			name: "compliant username",
-			args: args{username: "isrole1234eEvyH4mEPcCIT4tCvE131660656371"},
-			want: "isrole1234eEvyH4mEPcCIT4tCvE131660656371",
-		},
-		{
-			name: "short username",
-			args: args{username: "abcd"},
-			want: "abcd",
-		},
-		{
-			name: "username too long",
-			args: args{username: "vtokenredisrole1234eEvyH4mEPcCIT4tCvE131660656371"},
-			want: "isrole1234eEvyH4mEPcCIT4tCvE131660656371",
-		},
-		{
-			name: "username with non-alphanumeric characters",
-			args: args{username: "v_token_redis-role!/$}"},
-			want: "vtokenredis-role",
-		},
-		{
-			name: "username starting with a number",
-			args: args{username: "1bcd"},
-			want: "abcd",
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			if got := normaliseId(tt.args.username); got != tt.want {
-				t.Errorf("generateUserId() = %v, want %v", got, tt.want)
 			}
 		})
 	}


### PR DESCRIPTION
# Overview
Adding support for elasticache user groups.

A user only has access to the ElastiCache replication group or cluster only if it is part of the User Group associated with a particular cluster.

We are using a best effort approach to bootstrap the configuration for the user if needed while respecting any prior configuration that may be already in place:
```
If the replication group already has an associated user group, we use it
If not and a default user group already exists, we associate it
If not and a default group does not exist, we create and associate it
```

Modifying a user group is an extremely slow operation so we do our best to return as soon as it is safe and keep the number of modifications to a minimum.

Locking is handled AWS side. Whenever a resource is modified is can be in one of the 4 following states:
`active, creating, deleting, modifying`
A resource can only be modified when it is `active` and a non-active resource will always either disappear or return active once the on-going operation is completed. For this reason we block during entry but not during exit as AWS is responsible to "release" the lock, or return to an active state.
For these reasons waiting for the active state before returning is simply slowing things down.
We also need to be defensive and block until the active state is achieved before any operations because the cluster could be modified by a system different than vault or a user via a manual operation; so only waiting for an operation to complete before returning does not guarantee a new subsequent request is safe to proceed without blocking upon entry.

# Contributor Checklist
- [x] Add relevant docs to upstream Vault repository, or sufficient reasoning why docs won’t be added yet
- [x] Add output for any tests not ran in CI to the PR description (eg, acceptance tests)
```
/usr/local/go/bin/go tool test2json -t /tmp/GoLand/___redis_elasticache_client_test_go__1_.test -test.v -test.paniconexit0 -test.run ^\QTest_redisElastiCacheDB_Initialize\E|\QTest_redisElastiCacheDB_NewUser\E|\QTest_redisElastiCacheDB_UpdateUser\E|\QTest_redisElastiCacheDB_DeleteUser\E|\QTest_parseCreationCommands\E|\QTest_normaliseId\E$
=== RUN   Test_redisElastiCacheDB_Initialize
--- PASS: Test_redisElastiCacheDB_Initialize (1.19s)
=== RUN   Test_redisElastiCacheDB_Initialize/initialize_and_verify_connection_succeeds
{"@level":"debug","@message":"initializing AWS ElastiCache Redis client","@timestamp":"2022-08-26T11:47:05.280060-04:00"}
{"@level":"debug","@message":"Verifying connection to instance","@timestamp":"2022-08-26T11:47:05.280212-04:00","url":"master.vault-plugin-elasticache-test.6ylpiw.use1.cache.amazonaws.com:6379"}
    --- PASS: Test_redisElastiCacheDB_Initialize/initialize_and_verify_connection_succeeds (0.30s)
=== RUN   Test_redisElastiCacheDB_Initialize/initialize_with_invalid_config_fails
{"@level":"debug","@message":"initializing AWS ElastiCache Redis client","@timestamp":"2022-08-26T11:47:05.584075-04:00"}
{"@level":"debug","@message":"Verifying connection to instance","@timestamp":"2022-08-26T11:47:05.584205-04:00","url":"wrong"}
    --- PASS: Test_redisElastiCacheDB_Initialize/initialize_with_invalid_config_fails (0.88s)
=== RUN   Test_redisElastiCacheDB_NewUser
{"@level":"debug","@message":"initializing AWS ElastiCache Redis client","@timestamp":"2022-08-26T11:47:06.465695-04:00"}
{"@level":"debug","@message":"Verifying connection to instance","@timestamp":"2022-08-26T11:47:06.465819-04:00","url":"master.vault-plugin-elasticache-test.6ylpiw.use1.cache.amazonaws.com:6379"}
--- PASS: Test_redisElastiCacheDB_NewUser (109.99s)
=== RUN   Test_redisElastiCacheDB_NewUser/create_new_valid_user_succeeds
{"@level":"debug","@message":"creating new AWS ElastiCache Redis user","@timestamp":"2022-08-26T11:47:06.535975-04:00","role":"role"}
{"@level":"debug","@message":"deleting AWS ElastiCache Redis user","@timestamp":"2022-08-26T11:47:07.186186-04:00","username":"v_displ_role_4JC160t3FaS6fsZRUb5P_1661528826"}
    --- PASS: Test_redisElastiCacheDB_NewUser/create_new_valid_user_succeeds (1.02s)
=== RUN   Test_redisElastiCacheDB_NewUser/create_user_truncates_username
{"@level":"debug","@message":"creating new AWS ElastiCache Redis user","@timestamp":"2022-08-26T11:47:07.555327-04:00","role":"iAmEvenLongerTheApiWillDefinitelyRejectUsIfWeArePassedAsIsWithoutAnyModifications"}
{"@level":"debug","@message":"deleting AWS ElastiCache Redis user","@timestamp":"2022-08-26T11:48:56.098695-04:00","username":"v_iAmSu_iAmEvenLongerTheApiWillDefinitelyReject_xKJ9hlLoIjf10pz9peAR_1661528827"}
    --- PASS: Test_redisElastiCacheDB_NewUser/create_user_truncates_username (108.82s)
=== RUN   Test_redisElastiCacheDB_NewUser/create_user_with_invalid_password_fails
{"@level":"debug","@message":"creating new AWS ElastiCache Redis user","@timestamp":"2022-08-26T11:48:56.371597-04:00","role":"role"}
    --- PASS: Test_redisElastiCacheDB_NewUser/create_user_with_invalid_password_fails (0.08s)
=== RUN   Test_redisElastiCacheDB_NewUser/create_user_with_invalid_statements_fails
{"@level":"debug","@message":"creating new AWS ElastiCache Redis user","@timestamp":"2022-08-26T11:48:56.454186-04:00","role":"role"}
    --- PASS: Test_redisElastiCacheDB_NewUser/create_user_with_invalid_statements_fails (0.00s)
=== RUN   Test_redisElastiCacheDB_UpdateUser
{"@level":"debug","@message":"initializing AWS ElastiCache Redis client","@timestamp":"2022-08-26T11:48:56.454265-04:00"}
{"@level":"debug","@message":"Verifying connection to instance","@timestamp":"2022-08-26T11:48:56.454379-04:00","url":"master.vault-plugin-elasticache-test.6ylpiw.use1.cache.amazonaws.com:6379"}
{"@level":"debug","@message":"creating new AWS ElastiCache Redis user","@timestamp":"2022-08-26T11:48:56.716891-04:00","role":"role"}
--- PASS: Test_redisElastiCacheDB_UpdateUser (184.24s)
=== RUN   Test_redisElastiCacheDB_UpdateUser/update_password_of_existing_user_succeeds
{"@level":"debug","@message":"updating AWS ElastiCache Redis user","@timestamp":"2022-08-26T11:50:57.956213-04:00","username":"v_displ_role_PYzRdlo3DrpqA3JFrogc_1661528936"}
    --- PASS: Test_redisElastiCacheDB_UpdateUser/update_password_of_existing_user_succeeds (0.21s)
=== RUN   Test_redisElastiCacheDB_UpdateUser/update_password_of_non-existing_user_fails
{"@level":"debug","@message":"updating AWS ElastiCache Redis user","@timestamp":"2022-08-26T11:50:58.169767-04:00","username":"I do not exist"}
    --- PASS: Test_redisElastiCacheDB_UpdateUser/update_password_of_non-existing_user_fails (0.08s)
=== RUN   Test_redisElastiCacheDB_UpdateUser/update_to_invalid_password_fails
{"@level":"debug","@message":"updating AWS ElastiCache Redis user","@timestamp":"2022-08-26T11:50:58.251704-04:00","username":"v_displ_role_PYzRdlo3DrpqA3JFrogc_1661528936"}
{"@level":"debug","@message":"deleting AWS ElastiCache Redis user","@timestamp":"2022-08-26T11:52:00.270318-04:00","username":"v_displ_role_PYzRdlo3DrpqA3JFrogc_1661528936"}
    --- PASS: Test_redisElastiCacheDB_UpdateUser/update_to_invalid_password_fails (62.02s)
=== RUN   Test_redisElastiCacheDB_DeleteUser
{"@level":"debug","@message":"initializing AWS ElastiCache Redis client","@timestamp":"2022-08-26T11:52:00.689718-04:00"}
{"@level":"debug","@message":"Verifying connection to instance","@timestamp":"2022-08-26T11:52:00.690217-04:00","url":"master.vault-plugin-elasticache-test.6ylpiw.use1.cache.amazonaws.com:6379"}
{"@level":"debug","@message":"creating new AWS ElastiCache Redis user","@timestamp":"2022-08-26T11:52:00.764490-04:00","role":"role"}
--- PASS: Test_redisElastiCacheDB_DeleteUser (62.83s)
=== RUN   Test_redisElastiCacheDB_DeleteUser/delete_existing_user_succeeds
{"@level":"debug","@message":"deleting AWS ElastiCache Redis user","@timestamp":"2022-08-26T11:53:03.076053-04:00","username":"v_displ_role_D5YmqKYiGnzmBTKUTDNM_1661529120"}
    --- PASS: Test_redisElastiCacheDB_DeleteUser/delete_existing_user_succeeds (0.32s)
=== RUN   Test_redisElastiCacheDB_DeleteUser/delete_non-existing_user_is_lenient
{"@level":"debug","@message":"deleting AWS ElastiCache Redis user","@timestamp":"2022-08-26T11:53:03.394341-04:00","username":"I do not exist"}
{"@level":"debug","@message":"user does not exist or is being deleted, considering deletion successful","@timestamp":"2022-08-26T11:53:03.516500-04:00","user id":"Idonotexist"}
    --- PASS: Test_redisElastiCacheDB_DeleteUser/delete_non-existing_user_is_lenient (0.12s)
=== RUN   Test_parseCreationCommands
--- PASS: Test_parseCreationCommands (0.00s)
=== RUN   Test_parseCreationCommands/empty_command_returns_read-only_user
    --- PASS: Test_parseCreationCommands/empty_command_returns_read-only_user (0.00s)
=== RUN   Test_parseCreationCommands/single_command_with_multiple_rules_parses_correctly
    --- PASS: Test_parseCreationCommands/single_command_with_multiple_rules_parses_correctly (0.00s)
=== RUN   Test_parseCreationCommands/multiple_commands_with_multiple_rules_parses_correctly
    --- PASS: Test_parseCreationCommands/multiple_commands_with_multiple_rules_parses_correctly (0.00s)
=== RUN   Test_parseCreationCommands/empty_commands_are_tolerated
    --- PASS: Test_parseCreationCommands/empty_commands_are_tolerated (0.00s)
=== RUN   Test_parseCreationCommands/'on'_is_added_if_missing_for_convenience
    --- PASS: Test_parseCreationCommands/'on'_is_added_if_missing_for_convenience (0.00s)
=== RUN   Test_parseCreationCommands/'on'_is_ignored_if_passed_at_the_beginning
    --- PASS: Test_parseCreationCommands/'on'_is_ignored_if_passed_at_the_beginning (0.00s)
=== RUN   Test_parseCreationCommands/'on'_is_ignored_if_passed_explicitly_within_the_rules
    --- PASS: Test_parseCreationCommands/'on'_is_ignored_if_passed_explicitly_within_the_rules (0.00s)
=== RUN   Test_parseCreationCommands/'on'_is_ignored_if_passed_explicitly_at_the_end
    --- PASS: Test_parseCreationCommands/'on'_is_ignored_if_passed_explicitly_at_the_end (0.00s)
=== RUN   Test_parseCreationCommands/parsing_invalid_command_format_fails
    --- PASS: Test_parseCreationCommands/parsing_invalid_command_format_fails (0.00s)
=== RUN   Test_parseCreationCommands/creation_of_disabled_users_is_forbidden
    --- PASS: Test_parseCreationCommands/creation_of_disabled_users_is_forbidden (0.00s)
=== RUN   Test_normaliseId
--- PASS: Test_normaliseId (0.00s)
=== RUN   Test_normaliseId/compliant_username
    --- PASS: Test_normaliseId/compliant_username (0.00s)
=== RUN   Test_normaliseId/short_username
    --- PASS: Test_normaliseId/short_username (0.00s)
=== RUN   Test_normaliseId/username_too_long
    --- PASS: Test_normaliseId/username_too_long (0.00s)
=== RUN   Test_normaliseId/username_with_non-alphanumeric_characters
    --- PASS: Test_normaliseId/username_with_non-alphanumeric_characters (0.00s)
=== RUN   Test_normaliseId/username_starting_with_a_number
    --- PASS: Test_normaliseId/username_starting_with_a_number (0.00s)
PASS

Process finished with the exit code 0
```
- [x] Backwards compatible
