### PR TITLE
- removed local environment setup vars committed by mistake

### DIFF
--- a/bootstrap/terraform/local_environment_setup.sh
+++ b/bootstrap/terraform/local_environment_setup.sh
@@ -1,5 +1,0 @@
-export TEST_ELASTICACHE_USERNAME=AKIAZZ52RFZEAIKYRLDU &&\
-export TEST_ELASTICACHE_PASSWORD=sCZHj0URxGdnCwJfD6vHiN1mfCPTFESD8cx+TQDP &&\
-export TEST_ELASTICACHE_URL=master.vault-plugin-elasticache-test.6ylpiw.use1.cache.amazonaws.com:6379 &&\
-export TEST_ELASTICACHE_REGION=us-east-1 &&\
-export TEST_ELASTICACHE_USER=vault-test


### PR DESCRIPTION
# Overview
- removed local environment setup vars committed by mistake, user was for acceptance tests and no longer exists
