### PR TITLE
[CHANGELOG] Prepare for v0.8.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,14 @@
+## v0.8.0
+### October 2, 2025
+
+* Bump go version to 1.25.1 (#100)
+* [COMPLIANCE] Add Copyright and License Headers (#99)
+* Automated dependency upgrades (#93)
+* init changie (#98)
+* Add backport assistant workflow (#96)
+* Add backport assistant workflow (#95)
+* [Compliance] - PR Template Changes Required (#94)
+
 ## v0.7.0
 ### May 28, 2025
 


### PR DESCRIPTION
Changelog update for version [v0.8.0](https://github.com/hashicorp/vault-plugin-database-redis-elasticache/releases/tag/v0.8.0).

---
_This PR was generated by an automated workflow._

Full log: https://github.com/hashicorp/vault-plugin-release/actions/runs/18199230484

