### PR TITLE
[CHANGELOG] Prepare for v0.9.1 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## v0.9.1
+### March 20, 2026
+
+* Automated dependency upgrades (#108)
+
 ## v0.9.0
 ### March 18, 2026
 * Bump go version to 1.26.1 (#107)


### PR DESCRIPTION
Changelog update for version [v0.9.1](https://github.com/hashicorp/vault-plugin-database-redis-elasticache/releases/tag/v0.9.1).

---
_This PR was generated by an automated workflow._

Full log: https://github.com/hashicorp/vault-plugin-release/actions/runs/23326061034

