### PR TITLE
fix(db/redis-elasticache): restore backward-compatible region resolution after SDK v2 migration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Unreleased
 
 * Migrate AWS client from `aws-sdk-go` v1 to `aws-sdk-go-v2` (#112)
+* Fix: restore backward-compatible region resolution — `Initialize` no longer errors when no region is configured and IMDS is unavailable; falls back to `us-east-1`, matching v1 SDK behaviour
 
 ## v0.9.1
 ### March 20, 2026

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## Unreleased
 
 * Migrate AWS client from `aws-sdk-go` v1 to `aws-sdk-go-v2` (#112)
-* Fix: restore backward-compatible region resolution — `Initialize` no longer errors when no region is configured and IMDS is unavailable; falls back to `us-east-1`, matching v1 SDK behaviour
+* Fix: restore backward-compatible region resolution — `Initialize` no longer errors when no region is configured and IMDS is unavailable; falls back to `us-east-1`, matching v1 SDK behaviour (#113)
 
 ## v0.9.1
 ### March 20, 2026

--- a/redis_elasticache_client.go
+++ b/redis_elasticache_client.go
@@ -61,12 +61,13 @@ func (r *redisElastiCacheDB) Initialize(ctx context.Context, req dbplugin.Initia
 	}
 
 	// GetRegion checks plugin config, env vars (AWS_REGION/AWS_DEFAULT_REGION),
-	// then IMDS. Log full detail at debug; omit IMDS internals from the
-	// operator-facing error.
+	// then IMDS. If all sources fail (e.g. non-EC2 environment with no env vars
+	// set), fall back to DefaultRegion to preserve the v1 SDK behaviour where a
+	// missing region never hard-failed initialisation.
 	region, regionErr := awsutil.GetRegion(ctx, r.config.Region)
 	if regionErr != nil {
-		r.logger.Debug("region resolution failed", "error", regionErr)
-		return dbplugin.InitializeResponse{}, fmt.Errorf("unable to determine AWS region (set plugin 'region' or AWS_REGION/AWS_DEFAULT_REGION)")
+		region = awsutil.DefaultRegion
+		r.logger.Debug("region resolution failed, using default region", "region", region, "error", regionErr)
 	}
 	// RetrieveCreds can produce url.Error from network calls in the provider
 	// chain. Log full detail at debug; return a clean message to the operator.

--- a/redis_elasticache_client.go
+++ b/redis_elasticache_client.go
@@ -60,12 +60,18 @@ func (r *redisElastiCacheDB) Initialize(ctx context.Context, req dbplugin.Initia
 		secretKey = r.config.Password
 	}
 
-	// GetRegion checks plugin config, env vars (AWS_REGION/AWS_DEFAULT_REGION),
-	// then IMDS. If all sources fail (e.g. non-EC2 environment with no env vars
-	// set), fall back to DefaultRegion to preserve the v1 SDK behaviour where a
-	// missing region never hard-failed initialisation.
+	// GetRegion checks plugin config, env vars (AWS_REGION/AWS_DEFAULT_REGION), then
+	// IMDS. In non-EC2 environments IMDS is unavailable and GetRegion returns an error;
+	// fall back to DefaultRegion to preserve the v1 SDK contract where a missing region
+	// never hard-failed initialisation.
+	// TODO: remove this workaround once go-secure-stdlib/awsutil.GetRegion treats
+	// IMDS unavailability as non-fatal and falls through to DefaultRegion itself.
 	region, regionErr := awsutil.GetRegion(ctx, r.config.Region)
 	if regionErr != nil {
+		// Don't mask context cancellation or deadline as an IMDS failure.
+		if ctx.Err() != nil {
+			return dbplugin.InitializeResponse{}, ctx.Err()
+		}
 		region = awsutil.DefaultRegion
 		r.logger.Debug("region resolution failed, using default region", "region", region, "error", regionErr)
 	}

--- a/redis_elasticache_client_test.go
+++ b/redis_elasticache_client_test.go
@@ -109,6 +109,36 @@ func setUpClient(t *testing.T, r *redisElastiCacheDB, config map[string]interfac
 	}
 }
 
+// Test_redisElastiCacheDB_Initialize_NoRegion verifies that Initialize with no
+// region and verify_connection=false succeeds, matching the pre-v2 (v1 SDK)
+// behaviour where a missing region never hard-failed initialisation.
+func Test_redisElastiCacheDB_Initialize_NoRegion(t *testing.T) {
+	// Isolate from any ambient AWS configuration on the test machine or CI runner.
+	t.Setenv("AWS_REGION", "")
+	t.Setenv("AWS_DEFAULT_REGION", "")
+	t.Setenv("AWS_EC2_METADATA_DISABLED", "true")
+	t.Setenv("AWS_CONFIG_FILE", t.TempDir()+"/nonexistent")
+	t.Setenv("AWS_SHARED_CREDENTIALS_FILE", t.TempDir()+"/nonexistent")
+
+	r := &redisElastiCacheDB{
+		logger: hclog.NewNullLogger(),
+	}
+
+	cfg := map[string]interface{}{
+		"access_key_id":     "someaccesskey",
+		"secret_access_key": "somesecretkey",
+		"url":               "some-cache.abc.cfg.use1.cache.amazonaws.com",
+	}
+
+	_, err := r.Initialize(t.Context(), dbplugin.InitializeRequest{
+		Config:           cfg,
+		VerifyConnection: false,
+	})
+	if err != nil {
+		t.Fatalf("Initialize() with no region should not fail: %v", err)
+	}
+}
+
 func Test_redisElastiCacheDB_Initialize(t *testing.T) {
 	f, c, r, _ := setUpEnvironment()
 	skipIfAccTestNotEnabled(t)

--- a/redis_elasticache_client_test.go
+++ b/redis_elasticache_client_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/elasticache"
 	elasticachetypes "github.com/aws/aws-sdk-go-v2/service/elasticache/types"
 	"github.com/hashicorp/go-hclog"
+	awsutil "github.com/hashicorp/go-secure-stdlib/awsutil/v2"
 	"github.com/hashicorp/vault/sdk/database/dbplugin/v5"
 )
 
@@ -136,6 +137,15 @@ func Test_redisElastiCacheDB_Initialize_NoRegion(t *testing.T) {
 	})
 	if err != nil {
 		t.Fatalf("Initialize() with no region should not fail: %v", err)
+	}
+
+	// Assert the client is configured with the documented fallback region.
+	ec, ok := r.client.(*elasticache.Client)
+	if !ok {
+		t.Fatal("expected client to be *elasticache.Client")
+	}
+	if got := ec.Options().Region; got != awsutil.DefaultRegion {
+		t.Fatalf("expected client region %q, got %q", awsutil.DefaultRegion, got)
 	}
 }
 


### PR DESCRIPTION
## Problem

The v1 → v2 SDK migration (#112) introduced a regression in region resolution.

In v1, `ec2metadata.Available()` was called before `Region()` — so IMDS
unavailability (any non-EC2 environment) short-circuited cleanly to
`DefaultRegion`. In v2, `imds.Client.GetRegion()` does not separate
"IMDS unavailable" from "IMDS error"; both return an error. The migration
propagated that error directly as a hard `400` to callers.

Any operator configuring the plugin without an explicit `region` field —
relying on `AWS_REGION`, `AWS_DEFAULT_REGION`, or the previous implicit
`us-east-1` default — will hit this error in non-EC2 environments.

## Fix

Treat a `GetRegion` failure as an IMDS unavailability signal and fall back
to `awsutil.DefaultRegion`, preserving the v1 contract that `Initialize`
never fails solely due to a missing region. The fallback is logged at debug
level with the resolved region, so operators can observe it when needed.

Resolution order is unchanged: plugin config → env vars → IMDS → default.
Only the terminal case changes: error → logged fallback to `us-east-1`.

When `verify_connection=true`, the subsequent `DescribeUsers` call still
validates region correctness — a wrong region will surface there, not silently.

Operators with an explicit `region`, or with `AWS_REGION`/`AWS_DEFAULT_REGION`
set, are unaffected — those paths resolve before IMDS is consulted.
## Changes

- `redis_elasticache_client.go` — fall back to `awsutil.DefaultRegion` on
  `GetRegion` error instead of returning an error to the caller
- `redis_elasticache_client_test.go` — add `Test_redisElastiCacheDB_Initialize_NoRegion`:
  fully isolated unit test (no real AWS, env vars cleared, IMDS disabled)
  that runs without `ACC_TEST_ENABLED` and guards against future regression
- `CHANGELOG.md` — note the backward compat fix under Unreleased

## Testing
```
go test -run Test_redisElastiCacheDB_Initialize_NoRegion -v
--- PASS: Test_redisElastiCacheDB_Initialize_NoRegion (0.00s)
```
