### PR TITLE
fix(db/redis-elasticache): fix credential resolution when ~/.aws/credentials and static keys are both present

### DIFF
--- a/redis_elasticache_client.go
+++ b/redis_elasticache_client.go
@@ -78,8 +78,9 @@ func (r *redisElastiCacheDB) Initialize(ctx context.Context, req dbplugin.Initia
 	// RetrieveCreds can produce url.Error from network calls in the provider
 	// chain. Log full detail at debug; return a clean message to the operator.
 	// awsutil/v2 defaults withSharedCredentials=true, which adds an empty
-	// WithSharedCredentialsFiles("") override that prevents LoadDefaultConfig
-	// from finding a [default] profile even when ~/.aws/credentials exists.
+	// WithSharedCredentialsFiles("") override; when a [default] profile exists,
+	// LoadDefaultConfig attempts to load that profile's credentials from the
+	// injected empty path and fails.
 	// Disabling it here lets LoadDefaultConfig run its own default chain
 	// (env vars → ~/.aws/credentials → ~/.aws/config → IMDS) without
 	// interference, whether or not explicit keys are provided.

--- a/redis_elasticache_client.go
+++ b/redis_elasticache_client.go
@@ -77,7 +77,13 @@ func (r *redisElastiCacheDB) Initialize(ctx context.Context, req dbplugin.Initia
 	}
 	// RetrieveCreds can produce url.Error from network calls in the provider
 	// chain. Log full detail at debug; return a clean message to the operator.
-	cfg, err := awsutil.RetrieveCreds(ctx, accessKey, secretKey, "", r.logger)
+	// awsutil/v2 defaults withSharedCredentials=true, which adds an empty
+	// WithSharedCredentialsFiles("") override that prevents LoadDefaultConfig
+	// from finding a [default] profile even when ~/.aws/credentials exists.
+	// Disabling it here lets LoadDefaultConfig run its own default chain
+	// (env vars → ~/.aws/credentials → ~/.aws/config → IMDS) without
+	// interference, whether or not explicit keys are provided.
+	cfg, err := awsutil.RetrieveCreds(ctx, accessKey, secretKey, "", r.logger, awsutil.WithSharedCredentials(false))
 	if err != nil {
 		r.logger.Debug("credential resolution failed", "error", err)
 		return dbplugin.InitializeResponse{}, fmt.Errorf("unable to retrieve AWS credentials from provider chain")

--- a/redis_elasticache_client_test.go
+++ b/redis_elasticache_client_test.go
@@ -170,6 +170,9 @@ func Test_redisElastiCacheDB_Initialize_ExplicitCredsWithDefaultAWSProfile(t *te
 	// profile's credentials from that empty path and fail.
 	t.Setenv("AWS_SHARED_CREDENTIALS_FILE", t.TempDir()+"/nonexistent")
 	t.Setenv("AWS_EC2_METADATA_DISABLED", "true")
+	t.Setenv("AWS_ACCESS_KEY_ID", "")
+	t.Setenv("AWS_SECRET_ACCESS_KEY", "")
+	t.Setenv("AWS_SESSION_TOKEN", "")
 
 	r := &redisElastiCacheDB{
 		logger: hclog.NewNullLogger(),
@@ -188,6 +191,18 @@ func Test_redisElastiCacheDB_Initialize_ExplicitCredsWithDefaultAWSProfile(t *te
 	})
 	if err != nil {
 		t.Fatalf("Initialize() with explicit creds and [default] AWS profile should not fail: %v", err)
+	}
+
+	ec, ok := r.client.(*elasticache.Client)
+	if !ok {
+		t.Fatal("expected client to be *elasticache.Client")
+	}
+	creds, err := ec.Options().Credentials.Retrieve(t.Context())
+	if err != nil {
+		t.Fatalf("failed to retrieve credentials from client: %v", err)
+	}
+	if creds.AccessKeyID != "someaccesskey" {
+		t.Fatalf("expected static credentials from plugin config (AccessKeyID=%q), got %q", "someaccesskey", creds.AccessKeyID)
 	}
 }
 

--- a/redis_elasticache_client_test.go
+++ b/redis_elasticache_client_test.go
@@ -153,8 +153,8 @@ func Test_redisElastiCacheDB_Initialize_NoRegion(t *testing.T) {
 // that Initialize succeeds when explicit credentials are provided alongside a
 // [default] profile in ~/.aws/config. awsutil/v2 defaults
 // withSharedCredentials=true, which injects an empty WithSharedCredentialsFiles("")
-// override; when a [default] profile also exists, LoadDefaultConfig fails with
-// "failed to get shared config profile, default". Passing
+// override; when a [default] profile also exists, LoadDefaultConfig attempts to
+// load that profile's credentials from the empty path and fails. Passing
 // WithSharedCredentials(false) unconditionally prevents this interference and
 // lets the SDK run its own credential chain without a double-probe.
 func Test_redisElastiCacheDB_Initialize_ExplicitCredsWithDefaultAWSProfile(t *testing.T) {
@@ -166,7 +166,8 @@ func Test_redisElastiCacheDB_Initialize_ExplicitCredsWithDefaultAWSProfile(t *te
 	}
 	t.Setenv("AWS_CONFIG_FILE", configFile)
 	// Point credentials file at a non-existent path — awsutil was passing an
-	// empty file path which caused LoadDefaultConfig to fail to find the profile.
+	// empty file path, causing LoadDefaultConfig to attempt loading the [default]
+	// profile's credentials from that empty path and fail.
 	t.Setenv("AWS_SHARED_CREDENTIALS_FILE", t.TempDir()+"/nonexistent")
 	t.Setenv("AWS_EC2_METADATA_DISABLED", "true")
 

--- a/redis_elasticache_client_test.go
+++ b/redis_elasticache_client_test.go
@@ -173,6 +173,8 @@ func Test_redisElastiCacheDB_Initialize_ExplicitCredsWithDefaultAWSProfile(t *te
 	t.Setenv("AWS_ACCESS_KEY_ID", "")
 	t.Setenv("AWS_SECRET_ACCESS_KEY", "")
 	t.Setenv("AWS_SESSION_TOKEN", "")
+	t.Setenv("AWS_PROFILE", "")
+	t.Setenv("AWS_DEFAULT_PROFILE", "")
 
 	r := &redisElastiCacheDB{
 		logger: hclog.NewNullLogger(),
@@ -222,6 +224,8 @@ func Test_redisElastiCacheDB_Initialize_SharedCredentialsFile(t *testing.T) {
 	t.Setenv("AWS_EC2_METADATA_DISABLED", "true")
 	t.Setenv("AWS_ACCESS_KEY_ID", "")
 	t.Setenv("AWS_SECRET_ACCESS_KEY", "")
+	t.Setenv("AWS_PROFILE", "")
+	t.Setenv("AWS_DEFAULT_PROFILE", "")
 
 	r := &redisElastiCacheDB{
 		logger: hclog.NewNullLogger(),
@@ -263,6 +267,8 @@ func Test_redisElastiCacheDB_Initialize_EnvVarCredentials(t *testing.T) {
 	t.Setenv("AWS_EC2_METADATA_DISABLED", "true")
 	t.Setenv("AWS_ACCESS_KEY_ID", "envkeyid")
 	t.Setenv("AWS_SECRET_ACCESS_KEY", "envsecretkey")
+	t.Setenv("AWS_PROFILE", "")
+	t.Setenv("AWS_DEFAULT_PROFILE", "")
 
 	r := &redisElastiCacheDB{
 		logger: hclog.NewNullLogger(),
@@ -301,6 +307,8 @@ func Test_redisElastiCacheDB_Initialize_DeprecatedCredentials(t *testing.T) {
 	t.Setenv("AWS_CONFIG_FILE", t.TempDir()+"/nonexistent")
 	t.Setenv("AWS_SHARED_CREDENTIALS_FILE", t.TempDir()+"/nonexistent")
 	t.Setenv("AWS_EC2_METADATA_DISABLED", "true")
+	t.Setenv("AWS_PROFILE", "")
+	t.Setenv("AWS_DEFAULT_PROFILE", "")
 
 	r := &redisElastiCacheDB{
 		logger: hclog.NewNullLogger(),
@@ -365,8 +373,9 @@ func Test_redisElastiCacheDB_Initialize_NoCredentials(t *testing.T) {
 // in the plugin config are present, the static keys win. This covers the exact
 // scenario reported as a bug: providing ~/.aws/credentials alongside
 // access_key_id / secret_access_key in the database configuration.
-// awsutil.WithSharedCredentials(false) prevents the SDK's credentials-file
-// provider from interfering with the explicit static-credentials provider.
+// awsutil.WithSharedCredentials(false) prevents awsutil from injecting an empty
+// WithSharedCredentialsFiles("") override into LoadDefaultConfig, letting the
+// SDK run its own default credential chain without interference.
 func Test_redisElastiCacheDB_Initialize_StaticCredsOverrideSharedCredentialsFile(t *testing.T) {
 	// Write a credentials file with a [default] profile using DIFFERENT keys to
 	// make it visible if they are accidentally used instead of the static keys.
@@ -380,6 +389,8 @@ func Test_redisElastiCacheDB_Initialize_StaticCredsOverrideSharedCredentialsFile
 	t.Setenv("AWS_EC2_METADATA_DISABLED", "true")
 	t.Setenv("AWS_ACCESS_KEY_ID", "")
 	t.Setenv("AWS_SECRET_ACCESS_KEY", "")
+	t.Setenv("AWS_PROFILE", "")
+	t.Setenv("AWS_DEFAULT_PROFILE", "")
 
 	r := &redisElastiCacheDB{
 		logger: hclog.NewNullLogger(),

--- a/redis_elasticache_client_test.go
+++ b/redis_elasticache_client_test.go
@@ -224,6 +224,18 @@ func Test_redisElastiCacheDB_Initialize_SharedCredentialsFile(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Initialize() with shared credentials file should not fail: %v", err)
 	}
+
+	ec, ok := r.client.(*elasticache.Client)
+	if !ok {
+		t.Fatal("expected client to be *elasticache.Client")
+	}
+	creds, err := ec.Options().Credentials.Retrieve(t.Context())
+	if err != nil {
+		t.Fatalf("failed to retrieve credentials from client: %v", err)
+	}
+	if creds.AccessKeyID != "someaccesskey" {
+		t.Fatalf("expected credentials from shared credentials file (AccessKeyID=%q), got %q", "someaccesskey", creds.AccessKeyID)
+	}
 }
 
 // Test_redisElastiCacheDB_Initialize_EnvVarCredentials verifies that Initialize
@@ -252,6 +264,18 @@ func Test_redisElastiCacheDB_Initialize_EnvVarCredentials(t *testing.T) {
 	})
 	if err != nil {
 		t.Fatalf("Initialize() with env var credentials should not fail: %v", err)
+	}
+
+	ec, ok := r.client.(*elasticache.Client)
+	if !ok {
+		t.Fatal("expected client to be *elasticache.Client")
+	}
+	creds, err := ec.Options().Credentials.Retrieve(t.Context())
+	if err != nil {
+		t.Fatalf("failed to retrieve credentials from client: %v", err)
+	}
+	if creds.AccessKeyID != "envkeyid" {
+		t.Fatalf("expected credentials from env vars (AccessKeyID=%q), got %q", "envkeyid", creds.AccessKeyID)
 	}
 }
 
@@ -295,6 +319,10 @@ func Test_redisElastiCacheDB_Initialize_NoCredentials(t *testing.T) {
 	t.Setenv("AWS_DEFAULT_REGION", "")
 	t.Setenv("AWS_WEB_IDENTITY_TOKEN_FILE", "")
 	t.Setenv("AWS_ROLE_ARN", "")
+	t.Setenv("AWS_PROFILE", "")
+	t.Setenv("AWS_DEFAULT_PROFILE", "")
+	t.Setenv("AWS_CONTAINER_CREDENTIALS_RELATIVE_URI", "")
+	t.Setenv("AWS_CONTAINER_CREDENTIALS_FULL_URI", "")
 
 	r := &redisElastiCacheDB{
 		logger: hclog.NewNullLogger(),

--- a/redis_elasticache_client_test.go
+++ b/redis_elasticache_client_test.go
@@ -319,7 +319,7 @@ func Test_redisElastiCacheDB_Initialize_NoCredentials(t *testing.T) {
 // Test_redisElastiCacheDB_Initialize_StaticCredsOverrideSharedCredentialsFile
 // verifies that when both a real AWS credentials file and explicit static keys
 // in the plugin config are present, the static keys win. This covers the exact
-// scenario reported as a bug: providing ./aws/credentials alongside
+// scenario reported as a bug: providing ~/.aws/credentials alongside
 // access_key_id / secret_access_key in the database configuration.
 // awsutil.WithSharedCredentials(false) prevents the SDK's credentials-file
 // provider from interfering with the explicit static-credentials provider.
@@ -354,6 +354,18 @@ func Test_redisElastiCacheDB_Initialize_StaticCredsOverrideSharedCredentialsFile
 	})
 	if err != nil {
 		t.Fatalf("Initialize() with static creds and a credentials file should not fail: %v", err)
+	}
+
+	ec, ok := r.client.(*elasticache.Client)
+	if !ok {
+		t.Fatal("expected client to be *elasticache.Client")
+	}
+	creds, err := ec.Options().Credentials.Retrieve(t.Context())
+	if err != nil {
+		t.Fatalf("failed to retrieve credentials from client: %v", err)
+	}
+	if creds.AccessKeyID != "staticaccesskey" {
+		t.Fatalf("expected static credentials to take precedence (AccessKeyID=%q), got %q", "staticaccesskey", creds.AccessKeyID)
 	}
 }
 

--- a/redis_elasticache_client_test.go
+++ b/redis_elasticache_client_test.go
@@ -149,6 +149,214 @@ func Test_redisElastiCacheDB_Initialize_NoRegion(t *testing.T) {
 	}
 }
 
+// Test_redisElastiCacheDB_Initialize_ExplicitCredsWithDefaultAWSProfile verifies
+// that Initialize succeeds when explicit credentials are provided even when
+// ~/.aws/config contains a [default] profile. awsutil/v2 defaults
+// withSharedCredentials=true; when a [default] profile exists it adds
+// WithSharedConfigProfile("default") to the LoadDefaultConfig options, but also
+// passes an empty credentials file path, causing LoadDefaultConfig to fail with
+// "failed to get shared config profile, default". The fix passes
+// WithSharedCredentials(false) when explicit static keys are provided.
+func Test_redisElastiCacheDB_Initialize_ExplicitCredsWithDefaultAWSProfile(t *testing.T) {
+	// Write a temp AWS config file that contains a [default] profile — this is
+	// the environmental condition that triggered the bug.
+	configFile := t.TempDir() + "/config"
+	if err := os.WriteFile(configFile, []byte("[default]\nregion = us-west-2\n"), 0o600); err != nil {
+		t.Fatalf("failed to write temp AWS config file: %v", err)
+	}
+	t.Setenv("AWS_CONFIG_FILE", configFile)
+	// Point credentials file at a non-existent path — awsutil was passing an
+	// empty file path which caused LoadDefaultConfig to fail to find the profile.
+	t.Setenv("AWS_SHARED_CREDENTIALS_FILE", t.TempDir()+"/nonexistent")
+	t.Setenv("AWS_EC2_METADATA_DISABLED", "true")
+
+	r := &redisElastiCacheDB{
+		logger: hclog.NewNullLogger(),
+	}
+
+	cfg := map[string]interface{}{
+		"access_key_id":     "someaccesskey",
+		"secret_access_key": "somesecretkey",
+		"url":               "some-cache.abc.cfg.use1.cache.amazonaws.com",
+		"region":            "us-east-1",
+	}
+
+	_, err := r.Initialize(t.Context(), dbplugin.InitializeRequest{
+		Config:           cfg,
+		VerifyConnection: false,
+	})
+	if err != nil {
+		t.Fatalf("Initialize() with explicit creds and [default] AWS profile should not fail: %v", err)
+	}
+}
+
+// Test_redisElastiCacheDB_Initialize_SharedCredentialsFile verifies that
+// Initialize succeeds when no explicit credentials are given and credentials
+// come from a shared credentials file (~/.aws/credentials). This exercises
+// the documented fallback: "If omitted, authentication falls back on the AWS
+// credentials provider chain."
+func Test_redisElastiCacheDB_Initialize_SharedCredentialsFile(t *testing.T) {
+	credsFile := t.TempDir() + "/credentials"
+	content := "[default]\naws_access_key_id = someaccesskey\naws_secret_access_key = somesecretkey\n"
+	if err := os.WriteFile(credsFile, []byte(content), 0o600); err != nil {
+		t.Fatalf("failed to write temp credentials file: %v", err)
+	}
+	t.Setenv("AWS_SHARED_CREDENTIALS_FILE", credsFile)
+	t.Setenv("AWS_CONFIG_FILE", t.TempDir()+"/nonexistent")
+	t.Setenv("AWS_EC2_METADATA_DISABLED", "true")
+	t.Setenv("AWS_ACCESS_KEY_ID", "")
+	t.Setenv("AWS_SECRET_ACCESS_KEY", "")
+
+	r := &redisElastiCacheDB{
+		logger: hclog.NewNullLogger(),
+	}
+
+	cfg := map[string]interface{}{
+		"url":    "some-cache.abc.cfg.use1.cache.amazonaws.com",
+		"region": "us-east-1",
+	}
+
+	_, err := r.Initialize(t.Context(), dbplugin.InitializeRequest{
+		Config:           cfg,
+		VerifyConnection: false,
+	})
+	if err != nil {
+		t.Fatalf("Initialize() with shared credentials file should not fail: %v", err)
+	}
+}
+
+// Test_redisElastiCacheDB_Initialize_EnvVarCredentials verifies that Initialize
+// succeeds when no explicit credentials are set in the plugin config but
+// AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY are present in the environment.
+// This exercises the SDK default credential chain path (accessKey == "").
+func Test_redisElastiCacheDB_Initialize_EnvVarCredentials(t *testing.T) {
+	t.Setenv("AWS_CONFIG_FILE", t.TempDir()+"/nonexistent")
+	t.Setenv("AWS_SHARED_CREDENTIALS_FILE", t.TempDir()+"/nonexistent")
+	t.Setenv("AWS_EC2_METADATA_DISABLED", "true")
+	t.Setenv("AWS_ACCESS_KEY_ID", "envkeyid")
+	t.Setenv("AWS_SECRET_ACCESS_KEY", "envsecretkey")
+
+	r := &redisElastiCacheDB{
+		logger: hclog.NewNullLogger(),
+	}
+
+	cfg := map[string]interface{}{
+		"url":    "some-cache.abc.cfg.use1.cache.amazonaws.com",
+		"region": "us-east-1",
+	}
+
+	_, err := r.Initialize(t.Context(), dbplugin.InitializeRequest{
+		Config:           cfg,
+		VerifyConnection: false,
+	})
+	if err != nil {
+		t.Fatalf("Initialize() with env var credentials should not fail: %v", err)
+	}
+}
+
+// Test_redisElastiCacheDB_Initialize_DeprecatedCredentials verifies that the
+// deprecated username/password fields fall back correctly when access_key_id and
+// secret_access_key are absent.
+func Test_redisElastiCacheDB_Initialize_DeprecatedCredentials(t *testing.T) {
+	t.Setenv("AWS_CONFIG_FILE", t.TempDir()+"/nonexistent")
+	t.Setenv("AWS_SHARED_CREDENTIALS_FILE", t.TempDir()+"/nonexistent")
+	t.Setenv("AWS_EC2_METADATA_DISABLED", "true")
+
+	r := &redisElastiCacheDB{
+		logger: hclog.NewNullLogger(),
+	}
+
+	cfg := map[string]interface{}{
+		"username": "someaccesskey",
+		"password": "somesecretkey",
+		"url":      "some-cache.abc.cfg.use1.cache.amazonaws.com",
+		"region":   "us-east-1",
+	}
+
+	_, err := r.Initialize(t.Context(), dbplugin.InitializeRequest{
+		Config:           cfg,
+		VerifyConnection: false,
+	})
+	if err != nil {
+		t.Fatalf("Initialize() with deprecated username/password should not fail: %v", err)
+	}
+}
+
+// Test_redisElastiCacheDB_Initialize_NoCredentials verifies that Initialize fails
+// with a clear error when no credentials are available from any source.
+func Test_redisElastiCacheDB_Initialize_NoCredentials(t *testing.T) {
+	t.Setenv("AWS_CONFIG_FILE", t.TempDir()+"/nonexistent")
+	t.Setenv("AWS_SHARED_CREDENTIALS_FILE", t.TempDir()+"/nonexistent")
+	t.Setenv("AWS_EC2_METADATA_DISABLED", "true")
+	t.Setenv("AWS_ACCESS_KEY_ID", "")
+	t.Setenv("AWS_SECRET_ACCESS_KEY", "")
+	t.Setenv("AWS_REGION", "")
+	t.Setenv("AWS_DEFAULT_REGION", "")
+	t.Setenv("AWS_WEB_IDENTITY_TOKEN_FILE", "")
+	t.Setenv("AWS_ROLE_ARN", "")
+
+	r := &redisElastiCacheDB{
+		logger: hclog.NewNullLogger(),
+	}
+
+	cfg := map[string]interface{}{
+		"url":    "some-cache.abc.cfg.use1.cache.amazonaws.com",
+		"region": "us-east-1",
+	}
+
+	_, err := r.Initialize(t.Context(), dbplugin.InitializeRequest{
+		Config:           cfg,
+		VerifyConnection: false,
+	})
+	if err == nil {
+		t.Fatal("Initialize() with no credentials should fail")
+	}
+	if !strings.Contains(err.Error(), "unable to retrieve AWS credentials from provider chain") {
+		t.Fatalf("unexpected error message: %v", err)
+	}
+}
+
+// Test_redisElastiCacheDB_Initialize_StaticCredsOverrideSharedCredentialsFile
+// verifies that when both a real AWS credentials file and explicit static keys
+// in the plugin config are present, the static keys win. This covers the exact
+// scenario reported as a bug: providing ./aws/credentials alongside
+// access_key_id / secret_access_key in the database configuration.
+// awsutil.WithSharedCredentials(false) prevents the SDK's credentials-file
+// provider from interfering with the explicit static-credentials provider.
+func Test_redisElastiCacheDB_Initialize_StaticCredsOverrideSharedCredentialsFile(t *testing.T) {
+	// Write a credentials file with a [default] profile using DIFFERENT keys to
+	// make it visible if they are accidentally used instead of the static keys.
+	credsFile := t.TempDir() + "/credentials"
+	content := "[default]\naws_access_key_id = fileaccesskey\naws_secret_access_key = filesecretkey\n"
+	if err := os.WriteFile(credsFile, []byte(content), 0o600); err != nil {
+		t.Fatalf("failed to write temp credentials file: %v", err)
+	}
+	t.Setenv("AWS_SHARED_CREDENTIALS_FILE", credsFile)
+	t.Setenv("AWS_CONFIG_FILE", t.TempDir()+"/nonexistent")
+	t.Setenv("AWS_EC2_METADATA_DISABLED", "true")
+	t.Setenv("AWS_ACCESS_KEY_ID", "")
+	t.Setenv("AWS_SECRET_ACCESS_KEY", "")
+
+	r := &redisElastiCacheDB{
+		logger: hclog.NewNullLogger(),
+	}
+
+	cfg := map[string]interface{}{
+		"access_key_id":     "staticaccesskey",
+		"secret_access_key": "staticsecretkey",
+		"url":               "some-cache.abc.cfg.use1.cache.amazonaws.com",
+		"region":            "us-east-1",
+	}
+
+	_, err := r.Initialize(t.Context(), dbplugin.InitializeRequest{
+		Config:           cfg,
+		VerifyConnection: false,
+	})
+	if err != nil {
+		t.Fatalf("Initialize() with static creds and a credentials file should not fail: %v", err)
+	}
+}
+
 func Test_redisElastiCacheDB_Initialize(t *testing.T) {
 	f, c, r, _ := setUpEnvironment()
 	skipIfAccTestNotEnabled(t)

--- a/redis_elasticache_client_test.go
+++ b/redis_elasticache_client_test.go
@@ -150,13 +150,13 @@ func Test_redisElastiCacheDB_Initialize_NoRegion(t *testing.T) {
 }
 
 // Test_redisElastiCacheDB_Initialize_ExplicitCredsWithDefaultAWSProfile verifies
-// that Initialize succeeds when explicit credentials are provided even when
-// ~/.aws/config contains a [default] profile. awsutil/v2 defaults
-// withSharedCredentials=true; when a [default] profile exists it adds
-// WithSharedConfigProfile("default") to the LoadDefaultConfig options, but also
-// passes an empty credentials file path, causing LoadDefaultConfig to fail with
-// "failed to get shared config profile, default". The fix passes
-// WithSharedCredentials(false) when explicit static keys are provided.
+// that Initialize succeeds when explicit credentials are provided alongside a
+// [default] profile in ~/.aws/config. awsutil/v2 defaults
+// withSharedCredentials=true, which injects an empty WithSharedCredentialsFiles("")
+// override; when a [default] profile also exists, LoadDefaultConfig fails with
+// "failed to get shared config profile, default". Passing
+// WithSharedCredentials(false) unconditionally prevents this interference and
+// lets the SDK run its own credential chain without a double-probe.
 func Test_redisElastiCacheDB_Initialize_ExplicitCredsWithDefaultAWSProfile(t *testing.T) {
 	// Write a temp AWS config file that contains a [default] profile — this is
 	// the environmental condition that triggered the bug.


### PR DESCRIPTION

## PR Description

### Problem

`Initialize` fails with `"failed to get shared config profile, default"` when
the operator configures `access_key_id` / `secret_access_key` in the plugin
**and** the Vault host also has a `[default]` profile in `~/.aws/config` or
`~/.aws/credentials`.

Jira: https://hashicorp.atlassian.net/browse/VAULT-22272

### Root cause

`awsutil/v2` defaults to `withSharedCredentials=true`, which adds
`config.WithSharedCredentialsFiles([]string{""})` to the `LoadDefaultConfig`
options (empty string because `CredentialsConfig.Filename` is never set by
`RetrieveCreds`). When `~/.aws/config` contains a `[default]` profile, the SDK
also adds `WithSharedConfigProfile("default")` and then tries to load that
profile from the empty-string credentials file path — causing the call to fail
even though explicit static keys were also provided.

### Fix

Pass `awsutil.WithSharedCredentials(false)` to `RetrieveCreds`. This disables
awsutil's shared-credentials injection entirely and lets `LoadDefaultConfig` run
its own default chain without interference:

```
env vars (AWS_ACCESS_KEY_ID / AWS_SECRET_ACCESS_KEY)
  → ~/.aws/credentials (via AWS_SHARED_CREDENTIALS_FILE or default path)
  → ~/.aws/config
  → IMDS / ECS role
```

Explicit static keys are still applied via `WithCredentialsProvider` and take
precedence over every ambient source, as documented.

### Tests added

| Test | Scenario |
|---|---|
| `Test_redisElastiCacheDB_Initialize_ExplicitCredsWithDefaultAWSProfile` | Reproduces the bug: static keys + `[default]` profile in `~/.aws/config` |
| `Test_redisElastiCacheDB_Initialize_StaticCredsOverrideSharedCredentialsFile` | Static keys win over a real `AWS_SHARED_CREDENTIALS_FILE` with different credentials |
| `Test_redisElastiCacheDB_Initialize_SharedCredentialsFile` | No static keys → credentials file fallback works |
| `Test_redisElastiCacheDB_Initialize_EnvVarCredentials` | No static keys → `AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY` fallback works |
| `Test_redisElastiCacheDB_Initialize_DeprecatedCredentials` | `username` / `password` backward-compat fields still work |
| `Test_redisElastiCacheDB_Initialize_NoCredentials` | All sources absent → returns clear error |

### Testing

```
go test -run Test_redisElastiCacheDB_Initialize -v -count=1 ./...
```

All six new tests pass without live AWS credentials or network access.